### PR TITLE
tox.ini: Add {posargs}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@
 envlist = py26, py27, pypy, py32, py33, py34
 
 [testenv]
-commands = py.test
+commands = py.test {posargs}
 deps = pytest


### PR DESCRIPTION
So you can pass arguments through to py.test like:

    $ tox -e py27 -- -v test_path.py -k Makedir
    ...
    test_path.py::ReturnSelfTestCase::testMakedirs_pReturnsSelf PASSED
    test_path.py::ReturnSelfTestCase::testMakedirs_pReturnsSelfEvenIfExists PASSED