### PR TITLE
Add url method

### DIFF
--- a/path.py
+++ b/path.py
@@ -50,6 +50,16 @@ import contextlib
 import io
 
 try:
+    from urllib.parse import urljoin  # Python 3
+except ImportError:
+    from urlparse import urljoin  # Python 2
+
+try:
+    from urllib.request import pathname2url  # Python 3
+except ImportError:
+    from urllib import pathname2url  # Python 2
+
+try:
     import win32security
 except ImportError:
     pass
@@ -181,6 +191,9 @@ class Path(text_type):
     def __init__(self, other=''):
         if other is None:
             raise TypeError("Invalid initial value for path: None")
+
+    def url(self):
+        return urljoin('file:', pathname2url(str(self)))
 
     @classmethod
     @simple_cache

--- a/test_path.py
+++ b/test_path.py
@@ -938,8 +938,6 @@ class TestInPlace(object):
         assert 'lazy dog' in data
 
 
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason="requires non-Windows (POSIX)")
 def test_posix_url():
     assert Path('/var/log/xyzzy').url() == 'file:///var/log/xyzzy'
     assert Path('xyzzy').url() == 'file:///xyzzy'

--- a/test_path.py
+++ b/test_path.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 """ test_path.py - Test the path module.
 
@@ -936,6 +936,22 @@ class TestInPlace(object):
             data = stream.read()
         assert not 'Lorem' in data
         assert 'lazy dog' in data
+
+
+@pytest.mark.skipif(sys.platform.startswith('win'),
+                    reason="requires non-Windows (POSIX)")
+def test_posix_url():
+    assert Path('/var/log/xyzzy').url() == 'file:///var/log/xyzzy'
+    assert Path('xyzzy').url() == 'file:///xyzzy'
+
+
+@pytest.mark.skipif(not sys.platform.startswith('win'),
+                    reason="requires Windows")
+def test_windows_url():
+    assert Path(r'Foo\Bar').url() == 'file:///Foo/Bar'
+    assert Path(r'C:/Foo/Bar').url() == 'file:///C://Foo/Bar'
+    assert Path(r'C:\Foo\Bar').url() == 'file:///C:/Foo/Bar'
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
Convert a path to a URL with 'file' scheme

POSIX:

    >>> path('/foo/bar/dog.txt').url()
    'file:///foo/bar/dog.txt'

Windows:

    >>> path('C:\Python27\README.txt').url()
    'file:///C:/Python27/README.txt'