### PR TITLE
workaround for os.path without samefile()

### DIFF
--- a/path.py
+++ b/path.py
@@ -984,6 +984,9 @@ class Path(text_type):
 
     def samefile(self, other):
         """ .. seealso:: :func:`os.path.samefile` """
+        if not hasattr(self.module, 'samefile'):
+            other = Path(other).realpath().normpath().normcase()
+            return self.realpath().normpath().normcase() == other
         return self.module.samefile(self, other)
 
     def getatime(self):


### PR DESCRIPTION
`Path.samefile()` doesn't work in Python 2.x on Windows because there is no `os.path.samefile()`. This is a simple workaround.