### PR TITLE
Improve doc examples.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,18 @@ example:
     for f in d.files('*.py'):
         f.chmod(0o755)
 
+    # Globbing
+    for f in d.files('*.py'):
+        f.chmod(0o755)
+
+    # Changing the working directory:
+    with Path("somewhere"):
+        # cwd in now `somewhere`
+        ...
+
+    # Concatenate paths with /
+    foo_txt = Path("bar") / "foo.txt"
+
 ``path.py`` is `hosted at Github <https://github.com/jaraco/path.py>`_.
 
 Find `the documentation here <https://pathpy.readthedocs.io>`_.

--- a/path.py
+++ b/path.py
@@ -29,8 +29,18 @@ Example::
 
     from path import Path
     d = Path('/home/guido/bin')
+
+    # Globbing
     for f in d.files('*.py'):
         f.chmod(0o755)
+
+    # Changing the working directory:
+    with Path("somewhere"):
+        # cwd in now `somewhere`
+        ...
+
+    # Concatenate paths with /
+    foo_txt = Path("bar") / "foo.txt"
 """
 
 from __future__ import unicode_literals


### PR DESCRIPTION
Both the `with` and '/` features are very useful,
but hard to find if you don't know they exist :)

Plus, I think that:

```python
foo = bar_path / "foo"
```
is much more readable than

```python
foo = bar_path.joinpath("foo")
```

and also safer, because using the first option prevents you from writing `foo = bar_path.join("foo")` which is definitely never what you want ...

BTW: thanks for maintaining this awesome project!