### PR TITLE
Return strict str for __fspath__

### DIFF
--- a/path.py
+++ b/path.py
@@ -261,7 +261,7 @@ class Path(text_type):
         os.chdir(self._old_dir)
 
     def __fspath__(self):
-        return self
+        return text_type(self)
 
     @classmethod
     def getcwd(cls):


### PR DESCRIPTION
`__fspath__` returns a `path.Path` object. The doc in https://docs.python.org/3/library/os.html#os.PathLike.__fspath__ states:

> The method should only return a str or bytes object, with the preference being for str.

`path.Path` is a subclass of `str` so the current function is not wrong, but the intent of `__fspath__` is to return a standard string so this change should be logical. It is motivated by https://github.com/matplotlib/matplotlib/issues/11306