### PR TITLE
Doc fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,7 +99,8 @@
 ---
 
 - Refreshed project metadata based on `jaraco's project
-  skeleton <https://github.com/jaraco/skeleton/tree/spaces>_.
+  skeleton <https://github.com/jaraco/skeleton/tree/spaces>`_.
+
 - Releases are now automatically published via Travis-CI.
 - #111: More aggressively trap errors when importing
   ``pkg_resources``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ extensions = [
 
 pygments_style = 'sphinx'
 html_theme = 'alabaster'
-html_static_path = ['_static']
+html_static_path = []
 htmlhelp_basename = 'pathpydoc'
 templates_path = ['_templates']
 exclude_patterns = ['_build']

--- a/path.py
+++ b/path.py
@@ -749,6 +749,10 @@ class Path(text_type):
         of all the files users have in their :file:`bin` directories.
 
         .. seealso:: :func:`glob.glob`
+
+        .. note:: Glob is **not** recursive, even when using ``**``.
+                  To do recursive globbing see :func:`walk`,
+                  :func:`walkdirs` or :func:`walkfiles`.
         """
         cls = self._next_class
         return [cls(s) for s in glob.glob(self / pattern)]


### PR DESCRIPTION
The first commit fixes an old warning in the changelog. (Had to temporarly add `keep_warnings=True`  to `conf.py` to see where it was coming from)

The second commit fixes the warning about the static path. It may be fixed by adding a `.gitkeep` in the `_static` dir, instead or adding a favicon if you prefer.

The last commit was done after a colleague tried to use `path.glob` to do a recursive globbing. He got confused because he followed the link to the stdlib doc and did not understand why the`recursive` was not allowed.

We could add a note to explain that because `path` is compatible with Python2, and just delegates to the `glob` stdlib, we can't add a `recursive` argument to the `Path.glob()` method.

Or maybe we can just keep the note to redirect readers to the `walk()` methods.

Your call :)