### PR TITLE
Rename tempdir to TempDir and expose as part of public API.

### DIFF
--- a/path.py
+++ b/path.py
@@ -1414,7 +1414,7 @@ class Path(text_type):
         is not capable of storing a copy of the entire source tree.
         """
         update = kwargs.pop('update', False)
-        with tempdir() as _temp_dir:
+        with TempDir() as _temp_dir:
             # first copy the tree to a stage directory to support
             #  the parameters and behavior of copytree.
             stage = _temp_dir / str(hash(self))
@@ -1629,7 +1629,7 @@ class Multi:
         )
 
 
-class tempdir(Path):
+class TempDir(Path):
     """
     A temporary directory via :func:`tempfile.mkdtemp`, and
     constructed with the same parameters that you can use
@@ -1637,7 +1637,7 @@ class tempdir(Path):
 
     Example:
 
-        with tempdir() as d:
+        with TempDir() as d:
             # do stuff with the Path object "d"
 
         # here the directory is deleted automatically
@@ -1652,7 +1652,7 @@ class tempdir(Path):
 
     def __new__(cls, *args, **kwargs):
         dirname = tempfile.mkdtemp(*args, **kwargs)
-        return super(tempdir, cls).__new__(cls, dirname)
+        return super(TempDir, cls).__new__(cls, dirname)
 
     def __init__(self, *args, **kwargs):
         pass

--- a/path.py
+++ b/path.py
@@ -1658,7 +1658,11 @@ class TempDir(Path):
         pass
 
     def __enter__(self):
-        return self
+        # TempDir should return a Path version of itself and not itself
+        # so that a second context manager does not create a second
+        # temporary directory, but rather changes CWD to the location
+        # of the temporary directory.
+        return self._next_class(self)
 
     def __exit__(self, exc_type, exc_value, traceback):
         if not exc_value:

--- a/path.py
+++ b/path.py
@@ -1665,6 +1665,10 @@ class TempDir(Path):
             self.rmtree()
 
 
+# For backwards compatibility.
+tempdir = TempDir
+
+
 def _multi_permission_mask(mode):
     """
     Support multiple, comma-separated Unix chmod symbolic modes.

--- a/path.py
+++ b/path.py
@@ -110,7 +110,7 @@ def io_error_compat():
 ##############################################################################
 
 
-__all__ = ['Path', 'CaseInsensitivePattern']
+__all__ = ['Path', 'TempDir', 'CaseInsensitivePattern']
 
 
 LINESEPS = ['\r\n', '\r', '\n']
@@ -1635,7 +1635,7 @@ class TempDir(Path):
     constructed with the same parameters that you can use
     as a context manager.
 
-    Example:
+    Example::
 
         with TempDir() as d:
             # do stuff with the Path object "d"

--- a/test_path.py
+++ b/test_path.py
@@ -896,7 +896,7 @@ class TestTempDir:
         """
         d = TempDir()
         res = d.__enter__()
-        assert res is d
+        assert res == path.Path(d)
         (d / 'somefile.txt').touch()
         assert not isinstance(d / 'somefile.txt', TempDir)
         d.__exit__(None, None, None)

--- a/test_path.py
+++ b/test_path.py
@@ -33,7 +33,7 @@ import pytest
 import packaging.version
 
 import path
-from path import tempdir
+from path import TempDir
 from path import CaseInsensitivePattern as ci
 from path import SpecialResolver
 from path import Multi
@@ -271,7 +271,7 @@ class TestSelfReturn:
 
 class TestScratchDir:
     """
-    Tests that run in a temporary directory (does not test tempdir class)
+    Tests that run in a temporary directory (does not test TempDir class)
     """
     def test_context_manager(self, tmpdir):
         """Can be used as context manager for chdir."""
@@ -686,7 +686,7 @@ class TestScratchDir:
         test('UTF-16')
 
     def test_chunks(self, tmpdir):
-        p = (tempdir() / 'test.txt').touch()
+        p = (TempDir() / 'test.txt').touch()
         txt = "0123456789"
         size = 5
         p.write_text(txt)
@@ -700,13 +700,13 @@ class TestScratchDir:
         reason="samefile not present",
     )
     def test_samefile(self, tmpdir):
-        f1 = (tempdir() / '1.txt').touch()
+        f1 = (TempDir() / '1.txt').touch()
         f1.write_text('foo')
-        f2 = (tempdir() / '2.txt').touch()
+        f2 = (TempDir() / '2.txt').touch()
         f1.write_text('foo')
-        f3 = (tempdir() / '3.txt').touch()
+        f3 = (TempDir() / '3.txt').touch()
         f1.write_text('bar')
-        f4 = (tempdir() / '4.txt')
+        f4 = (TempDir() / '4.txt')
         f1.copyfile(f4)
 
         assert os.path.samefile(f1, f2) == f1.samefile(f2)
@@ -872,7 +872,7 @@ class TestTempDir:
         """
         One should be able to readily construct a temporary directory
         """
-        d = tempdir()
+        d = TempDir()
         assert isinstance(d, path.Path)
         assert d.exists()
         assert d.isdir()
@@ -881,24 +881,24 @@ class TestTempDir:
 
     def test_next_class(self):
         """
-        It should be possible to invoke operations on a tempdir and get
+        It should be possible to invoke operations on a TempDir and get
         Path classes.
         """
-        d = tempdir()
+        d = TempDir()
         sub = d / 'subdir'
         assert isinstance(sub, path.Path)
         d.rmdir()
 
     def test_context_manager(self):
         """
-        One should be able to use a tempdir object as a context, which will
+        One should be able to use a TempDir object as a context, which will
         clean up the contents after.
         """
-        d = tempdir()
+        d = TempDir()
         res = d.__enter__()
         assert res is d
         (d / 'somefile.txt').touch()
-        assert not isinstance(d / 'somefile.txt', tempdir)
+        assert not isinstance(d / 'somefile.txt', TempDir)
         d.__exit__(None, None, None)
         assert not d.exists()
 
@@ -906,10 +906,10 @@ class TestTempDir:
         """
         The context manager will not clean up if an exception occurs.
         """
-        d = tempdir()
+        d = TempDir()
         d.__enter__()
         (d / 'somefile.txt').touch()
-        assert not isinstance(d / 'somefile.txt', tempdir)
+        assert not isinstance(d / 'somefile.txt', TempDir)
         d.__exit__(TypeError, TypeError('foo'), None)
         assert d.exists()
 
@@ -919,7 +919,7 @@ class TestTempDir:
         provide a temporry directory that will be deleted after that.
         """
 
-        with tempdir() as d:
+        with TempDir() as d:
             assert d.isdir()
         assert not d.isdir()
 


### PR DESCRIPTION
This PR renames `tempdir` to `TempDir` (but keeps `tempdir` for backwards-compatibility), adds it to `__all__`, and places it into the documentation.

Additionally, I have made one more change that fixes a behavior that I believe is not the intended behavior of `TempDir`. This was added in commit 94c48fb. Basically, the old behavior of using a `TempDir` instance in a context manager was to create a *second* temporary directory, and I do not believe this was intentional nor do I believe it Passes the Principle of Least Astonishment.

Consider the following code:

```python
>>> from path import Path, TempDir
>>> with TempDir() as td:  # Create the temporary directory.
...     with td:  # Enter the temporary directory... right?
...               # Wrong! It created another temporary directory!
...

# Current workaround for the above behavior:

>>> with TempDir() as td:
...     with Path(td):
...
```

I'm not sure the user should be required to coerce the `TempDir` instance to `Path` to change the CWD in a with context.  If this change is not desired I would be happy to revert that commit.

If accepted, this will close issue #142.