### PR TITLE
Replace use of distutils with a bespoke implementation of merge_tree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@
   be patched similarly in the ``patch_for_linux_python2``
   function.
 
+- #141: For merge_tree, instead of relying on the deprecated
+  distutils module, implement merge_tree explicitly. The
+  ``update`` parameter is deprecated, instead superseded
+  by a ``copy_function`` parameter and an ``only_newer``
+  wrapper for any copy function.
+
 11.3.0
 ------
 

--- a/path.py
+++ b/path.py
@@ -1455,7 +1455,7 @@ class Path(text_type):
                 target = source.readlink()
                 target.symlink(dest)
             elif source.isdir():
-                source.mergetree(
+                source.merge_tree(
                     dest,
                     symlinks=symlinks,
                     update=update,

--- a/path.py
+++ b/path.py
@@ -1422,14 +1422,21 @@ class Path(text_type):
         Copy entire contents of self to dst, overwriting existing
         contents in dst with those in self.
 
-        If the additional keyword `update` is True, each
-        `src` will only be copied if `dst` does not exist,
-        or `src` is newer than `dst`.
+        To avoid overwriting newer files, supply a copy function
+        wrapped in ``only_newer``. For example::
+
+            src.merge_tree(dst, copy_function=only_newer(shutil.copy2))
         """
         dst = self._next_class(dst)
         dst.makedirs_p()
 
-        copy_func = only_newer(copy_function) if update else copy_function
+        if update:
+            warnings.warn(
+                "Update is deprecated; "
+                "use copy_function=only_newer(shutil.copy2)",
+                DeprecationWarning,
+            )
+            copy_function = only_newer(copy_function)
 
         _ignored = ignore(self, os.listdir(self))
 
@@ -1446,11 +1453,11 @@ class Path(text_type):
                     dest,
                     symlinks=symlinks,
                     update=update,
-                    copy_function=copy_func,
+                    copy_function=copy_function,
                     ignore=ignore,
                 )
             else:
-                copy_func(source, dest)
+                copy_function(source, dest)
 
         self.copystat(dst)
 

--- a/path.py
+++ b/path.py
@@ -59,7 +59,6 @@ import operator
 import re
 import contextlib
 import io
-import distutils.dir_util
 import importlib
 import itertools
 import platform
@@ -96,6 +95,7 @@ if PY2:
     getcwdu = os.getcwdu
     map = itertools.imap
     FileNotFoundError = OSError
+    itertools.filterfalse = itertools.ifilterfalse
 
 
 @contextlib.contextmanager
@@ -1412,7 +1412,12 @@ class Path(text_type):
 
     cd = chdir
 
-    def merge_tree(self, dst, symlinks=False, *args, **kwargs):
+    def merge_tree(
+            self, dst, symlinks=False,
+            # *
+            update=False,
+            copy_function=shutil.copy2,
+            ignore=lambda dir, contents: []):
         """
         Copy entire contents of self to dst, overwriting existing
         contents in dst with those in self.
@@ -1420,26 +1425,43 @@ class Path(text_type):
         If the additional keyword `update` is True, each
         `src` will only be copied if `dst` does not exist,
         or `src` is newer than `dst`.
-
-        Note that the technique employed stages the files in a temporary
-        directory first, so this function is not suitable for merging
-        trees with large files, especially if the temporary directory
-        is not capable of storing a copy of the entire source tree.
         """
-        update = kwargs.pop('update', False)
-        with TempDir() as _temp_dir:
-            # first copy the tree to a stage directory to support
-            #  the parameters and behavior of copytree.
-            stage = _temp_dir / str(hash(self))
-            self.copytree(stage, symlinks, *args, **kwargs)
-            # now copy everything from the stage directory using
-            #  the semantics of dir_util.copy_tree
-            distutils.dir_util.copy_tree(
-                stage,
-                dst,
-                preserve_symlinks=symlinks,
-                update=update,
+        def copy_newer(src, dst, follow_symlinks=True):
+            is_newer_dst = (
+                self.module.exists(dst)
+                and self.module.getmtime(dst) >= self.module.getmtime(src)
             )
+            if is_newer_dst:
+                return dst
+            return copy_function(src, dst, follow_symlinks=follow_symlinks)
+
+        dst = self._next_class(dst)
+        dst.makedirs_p()
+
+        copy_func = copy_newer if update else copy_function
+
+        _ignored = ignore(self, os.listdir(self))
+
+        def ignored(item):
+            return item.name in _ignored
+
+        for source in itertools.filterfalse(ignored, self.listdir()):
+            dest = dst / source.name
+            if symlinks and source.islink():
+                target = source.readlink()
+                target.symlink(dest)
+            elif source.isdir():
+                source.mergetree(
+                    dest,
+                    symlinks=symlinks,
+                    update=update,
+                    copy_function=copy_func,
+                    ignore=ignore,
+                )
+            else:
+                copy_func(source, dest)
+
+        self.copystat(dst)
 
     #
     # --- Special stuff from os

--- a/path.py
+++ b/path.py
@@ -1438,12 +1438,13 @@ class Path(text_type):
             )
             copy_function = only_newer(copy_function)
 
-        _ignored = ignore(self, os.listdir(self))
+        sources = self.listdir()
+        _ignored = ignore(self, [item.name for item in sources])
 
         def ignored(item):
             return item.name in _ignored
 
-        for source in itertools.filterfalse(ignored, self.listdir()):
+        for source in itertools.filterfalse(ignored, sources):
             dest = dst / source.name
             if symlinks and source.islink():
                 target = source.readlink()

--- a/path.py
+++ b/path.py
@@ -1422,6 +1422,10 @@ class Path(text_type):
         Copy entire contents of self to dst, overwriting existing
         contents in dst with those in self.
 
+        Pass ``symlinks=True`` to copy symbolic links as links.
+
+        Accepts a ``copy_function``, similar to copytree.
+
         To avoid overwriting newer files, supply a copy function
         wrapped in ``only_newer``. For example::
 
@@ -1435,6 +1439,7 @@ class Path(text_type):
                 "Update is deprecated; "
                 "use copy_function=only_newer(shutil.copy2)",
                 DeprecationWarning,
+                stacklevel=2,
             )
             copy_function = only_newer(copy_function)
 

--- a/test_path.py
+++ b/test_path.py
@@ -851,6 +851,20 @@ class TestMergeTree:
         assert self.subdir_b.isdir()
         assert self.subdir_b.listdir() == [self.subdir_b / self.test_file.name]
 
+    def test_only_newer(self):
+        """
+        merge_tree should accept a copy_function in which only
+        newer files are copied and older files do not overwrite
+        newer copies in the dest.
+        """
+        target = self.subdir_b / 'testfile.txt'
+        target.write_text('this is newer')
+        self.subdir_a.merge_tree(
+            self.subdir_b,
+            copy_function=path.only_newer(shutil.copy2),
+        )
+        assert target.text() == 'this is newer'
+
 
 class TestChdir:
     def test_chdir_or_cd(self, tmpdir):


### PR DESCRIPTION
As reported in #141, and following the [copytree example](https://docs.python.org/3/library/shutil.html#copytree-example), I've started work on this replacement implementation.