### PR TITLE
Add follow_symlinks keyword argument to walkdirs and walkfile method

### DIFF
--- a/path.py
+++ b/path.py
@@ -680,7 +680,7 @@ class Path(text_type):
             for subsubdir in child.walkdirs(pattern, errors, follow_symlinks):
                 yield subsubdir
 
-    def walkfiles(self, pattern=None, errors='strict'):
+    def walkfiles(self, pattern=None, errors='strict', follow_symlinks=True):
         """ D.walkfiles() -> iterator over files in D, recursively.
 
         The optional argument `pattern` limits the results to files
@@ -720,12 +720,15 @@ class Path(text_type):
                     continue
                 else:
                     raise
+                    
+            if child.islink() and not follow_symlinks:
+                continue
 
             if isfile:
                 if pattern is None or child.fnmatch(pattern):
                     yield child
             elif isdir:
-                for f in child.walkfiles(pattern, errors):
+                for f in child.walkfiles(pattern, errors, follow_symlinks):
                     yield f
 
     def fnmatch(self, pattern, normcase=None):
@@ -1887,7 +1890,7 @@ class FastPath(Path):
             for subsubdir in child.__walkdirs(pattern, normcase, errors, follow_symlinks):
                 yield subsubdir
 
-    def walkfiles(self, pattern=None, errors='strict'):
+    def walkfiles(self, pattern=None, errors='strict', follow_symlinks=True):
         if errors not in ('strict', 'warn', 'ignore'):
             raise ValueError("invalid errors parameter")
 
@@ -1896,9 +1899,9 @@ class FastPath(Path):
         else:
             normcase = None
 
-        return self.__walkfiles(pattern, normcase, errors)
+        return self.__walkfiles(pattern, normcase, errors, follow_symlinks)
 
-    def __walkfiles(self, pattern, normcase, errors):
+    def __walkfiles(self, pattern, normcase, errors, follow_symlinks):
         """ Prepared version of walkfiles """
         try:
             childList = self.listdir()
@@ -1930,11 +1933,14 @@ class FastPath(Path):
                 else:
                     raise
 
+            if child.islink() and not follow_symlinks:
+                continue
+
             if isfile:
                 if pattern is None or child.__fnmatch(pattern, normcase):
                     yield child
             elif isdir:
-                for f in child.__walkfiles(pattern, normcase, errors):
+                for f in child.__walkfiles(pattern, normcase, errors, follow_symlinks):
                     yield f
 
     def __fnmatch(self, pattern, normcase):

--- a/path.py
+++ b/path.py
@@ -638,7 +638,7 @@ class Path(text_type):
                 for item in child.walk(pattern, errors):
                     yield item
 
-    def walkdirs(self, pattern=None, errors='strict'):
+    def walkdirs(self, pattern=None, errors='strict', follow_symlinks=True):
         """ D.walkdirs() -> iterator over subdirs, recursively.
 
         With the optional `pattern` argument, this yields only
@@ -650,6 +650,9 @@ class Path(text_type):
         error occurs.  The default is ``'strict'``, which causes an
         exception.  The other allowed values are ``'warn'`` (which
         reports the error via :func:`warnings.warn()`), and ``'ignore'``.
+
+        If the `follow_symlinks=` keyword argument value is ``False``,
+        not to follow symbolic links.
         """
         if errors not in ('strict', 'warn', 'ignore'):
             raise ValueError("invalid errors parameter")
@@ -669,9 +672,12 @@ class Path(text_type):
                 raise
 
         for child in dirs:
+            if child.islink() and not follow_symlinks:
+                continue
+
             if pattern is None or child.fnmatch(pattern):
                 yield child
-            for subsubdir in child.walkdirs(pattern, errors):
+            for subsubdir in child.walkdirs(pattern, errors, follow_symlinks):
                 yield subsubdir
 
     def walkfiles(self, pattern=None, errors='strict'):
@@ -1845,7 +1851,7 @@ class FastPath(Path):
                 for item in child.__walk(pattern, normcase, errors):
                     yield item
 
-    def walkdirs(self, pattern=None, errors='strict'):
+    def walkdirs(self, pattern=None, errors='strict', follow_symlinks=True):
         if errors not in ('strict', 'warn', 'ignore'):
             raise ValueError("invalid errors parameter")
 
@@ -1854,9 +1860,9 @@ class FastPath(Path):
         else:
             normcase = None
 
-        return self.__walkdirs(pattern, normcase, errors)
+        return self.__walkdirs(pattern, normcase, errors, follow_symlinks)
 
-    def __walkdirs(self, pattern, normcase, errors):
+    def __walkdirs(self, pattern, normcase, errors, follow_symlinks):
         """ Prepared version of walkdirs """
         try:
             dirs = self.dirs()
@@ -1873,9 +1879,12 @@ class FastPath(Path):
                 raise
 
         for child in dirs:
+            if child.islink() and not follow_symlinks:
+                continue
+
             if pattern is None or child.__fnmatch(pattern, normcase):
                 yield child
-            for subsubdir in child.__walkdirs(pattern, normcase, errors):
+            for subsubdir in child.__walkdirs(pattern, normcase, errors, follow_symlinks):
                 yield subsubdir
 
     def walkfiles(self, pattern=None, errors='strict'):

--- a/path.py
+++ b/path.py
@@ -720,7 +720,7 @@ class Path(text_type):
                     continue
                 else:
                     raise
-                    
+
             if child.islink() and not follow_symlinks:
                 continue
 
@@ -1887,7 +1887,8 @@ class FastPath(Path):
 
             if pattern is None or child.__fnmatch(pattern, normcase):
                 yield child
-            for subsubdir in child.__walkdirs(pattern, normcase, errors, follow_symlinks):
+            for subsubdir in child.__walkdirs(
+                    pattern, normcase, errors, follow_symlinks):
                 yield subsubdir
 
     def walkfiles(self, pattern=None, errors='strict', follow_symlinks=True):
@@ -1940,7 +1941,8 @@ class FastPath(Path):
                 if pattern is None or child.__fnmatch(pattern, normcase):
                     yield child
             elif isdir:
-                for f in child.__walkfiles(pattern, normcase, errors, follow_symlinks):
+                for f in child.__walkfiles(
+                        pattern, normcase, errors, follow_symlinks):
                     yield f
 
     def __fnmatch(self, pattern, normcase):

--- a/test_path.py
+++ b/test_path.py
@@ -587,6 +587,42 @@ class TestScratchDir:
         self.assertList(d.walkfiles('*.tmp'), [e / 'x.tmp' for e in dirs])
         self.assertList(d.walkdirs('*.tmp'), [d / 'xdir.tmp'])
 
+    def test_follow_symlink(self, tmpdir):
+        d = Path(tmpdir)
+        dirs = [
+            d,
+            d / 'xdir1',
+            d / 'xdir1' / 'xsubdir',
+            d / 'xdir2',
+        ]
+
+        for e in dirs:
+            if not e.isdir():
+                e.makedirs()
+
+        Path(d / 'xdir1' / 'x.tmp').touch()
+        Path(d / 'xdir1').symlink(d / 'xdir2' / 'symldir')
+
+        # Follow symbolic link
+        self.assertList(
+            d.walkdirs(),
+            [
+                d / 'xdir1',
+                d / 'xdir1' / 'xsubdir',
+                d / 'xdir2',
+                d / 'xdir2' / 'symldir',
+                d / 'xdir2' / 'symldir' / 'xsubdir',
+            ])
+
+        # Not follow symbolic link
+        self.assertList(
+            d.walkdirs(follow_symlinks=False),
+            [
+                d / 'xdir1',
+                d / 'xdir1' / 'xsubdir',
+                d / 'xdir2',
+            ])
+
     def test_unicode(self, tmpdir):
         d = Path(tmpdir)
         p = d / 'unicode.txt'

--- a/test_path.py
+++ b/test_path.py
@@ -587,6 +587,10 @@ class TestScratchDir:
         self.assertList(d.walkfiles('*.tmp'), [e / 'x.tmp' for e in dirs])
         self.assertList(d.walkdirs('*.tmp'), [d / 'xdir.tmp'])
 
+    @pytest.mark.skipif(
+        not hasattr(os, 'symlink'),
+        reason="os.symlink not supported"
+    )
     def test_follow_symlink(self, tmpdir):
         d = Path(tmpdir)
         dirs = [

--- a/test_path.py
+++ b/test_path.py
@@ -601,6 +601,7 @@ class TestScratchDir:
                 e.makedirs()
 
         Path(d / 'xdir1' / 'x.tmp').touch()
+        Path(d / 'xdir1' / 'x.tmp').symlink(d / 'xdir2' / 'l.tmp')
         Path(d / 'xdir1').symlink(d / 'xdir2' / 'symldir')
 
         # Follow symbolic link
@@ -613,6 +614,13 @@ class TestScratchDir:
                 d / 'xdir2' / 'symldir',
                 d / 'xdir2' / 'symldir' / 'xsubdir',
             ])
+        self.assertList(
+            d.walkfiles(),
+            [
+                d / 'xdir1' / 'x.tmp',
+                d / 'xdir2' / 'symldir' / 'x.tmp',
+                d / 'xdir2' / 'l.tmp',
+            ])
 
         # Not follow symbolic link
         self.assertList(
@@ -622,6 +630,9 @@ class TestScratchDir:
                 d / 'xdir1' / 'xsubdir',
                 d / 'xdir2',
             ])
+        self.assertList(
+            d.walkfiles(follow_symlinks=False),
+            [d / 'xdir1' / 'x.tmp'])
 
     def test_unicode(self, tmpdir):
         d = Path(tmpdir)


### PR DESCRIPTION
This PR enables to avoid recursive directory listing caused by symbolic links.
If the `follow_symlinks=` keyword argument value is ``False`` not to follow symbolic links while walk recursively into subdirectories.
(defaults to ``True``: behave the same as the current version) 
