### PR TITLE
Support more flexible patterns for pattern matching in listdir and walk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+11.5.0
+------
+
+- #156: Re-wrote the handling of pattern matches for
+  ``listdir``, ``walk``, and related methods, allowing
+  the pattern to be a more complex object. This approach
+  drastically simplifies the code and obviates the
+  ``CaseInsensitivePattern`` and ``FastPath`` classes.
+  Now the main ``Path`` class should be as performant
+  as ``FastPath`` and case-insensitive matches can be
+  readily constructed using the new
+  ``path.matchers.CaseInsensitive`` class.
+
 11.4.1
 ------
 

--- a/test_path.py
+++ b/test_path.py
@@ -38,7 +38,7 @@ import packaging.version
 
 import path
 from path import TempDir
-from path import CaseInsensitivePattern as ci
+from path import matchers
 from path import SpecialResolver
 from path import Multi
 
@@ -1036,10 +1036,10 @@ class TestPatternMatching:
         p = Path(tmpdir)
         (p / 'sub').mkdir()
         (p / 'File').touch()
-        assert p.listdir(ci('S*')) == [p / 'sub']
-        assert p.listdir(ci('f*')) == [p / 'File']
-        assert p.files(ci('S*')) == []
-        assert p.dirs(ci('f*')) == []
+        assert p.listdir(matchers.CaseInsensitive('S*')) == [p / 'sub']
+        assert p.listdir(matchers.CaseInsensitive('f*')) == [p / 'File']
+        assert p.files(matchers.CaseInsensitive('S*')) == []
+        assert p.dirs(matchers.CaseInsensitive('f*')) == []
 
     def test_walk_case_insensitive(self, tmpdir):
         p = Path(tmpdir)
@@ -1048,7 +1048,7 @@ class TestPatternMatching:
         (p / 'sub1' / 'foo' / 'bar.Txt').touch()
         (p / 'sub2' / 'foo' / 'bar.TXT').touch()
         (p / 'sub2' / 'foo' / 'bar.txt.bz2').touch()
-        files = list(p.walkfiles(ci('*.txt')))
+        files = list(p.walkfiles(matchers.CaseInsensitive('*.txt')))
         assert len(files) == 2
         assert p / 'sub2' / 'foo' / 'bar.TXT' in files
         assert p / 'sub1' / 'foo' / 'bar.Txt' in files

--- a/test_path.py
+++ b/test_path.py
@@ -50,7 +50,7 @@ def p(**choices):
     return choices[os.name]
 
 
-@pytest.fixture(autouse=True, params=[path.Path, path.FastPath])
+@pytest.fixture(autouse=True, params=[path.Path])
 def path_class(request, monkeypatch):
     """
     Invoke tests on any number of Path classes.


### PR DESCRIPTION
These commits change the way the `pattern` parameter (now `match`) are handled, allowing rich objects to be supplied, objects that perform better, obviating the FastPath and eliminating lots of duplicate code. This simplification will help in implementing #154.