### PR TITLE
alias `Path` to `path` for backwards-compatibility

### DIFF
--- a/path.py
+++ b/path.py
@@ -1562,6 +1562,8 @@ class Path(text_type):
         """
         return functools.partial(SpecialResolver, cls)
 
+path = Path
+
 
 def only_newer(copy_func):
     """


### PR DESCRIPTION
This patch just adds an alias for the old name of `path` for backwards-compatibility for projects that use version <= 6.2, since use of path.py tends to be fairly extensive when it is used, and thus difficult to upgrade to a breaking change, especially if dependencies also use it.