### PR TITLE
Remove support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 
 python:
-- 2.7
 - 3.6
 - &latest_py3 3.7
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+12.0
+---
+
+- #148: Dropped support for Python 2.7 and 3.4.
+
 11.5.2
 ------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python36-x64"
-    - PYTHON: "C:\\Python27-x64"
 
 install:
   # symlink python from a directory with a space

--- a/path.py
+++ b/path.py
@@ -1162,12 +1162,8 @@ class Path(str):
     def mkdir_p(self, mode=0o777):
         """ Like :meth:`mkdir`, but does not raise an exception if the
         directory already exists. """
-        try:
+        with contextlib.suppress(FileExistsError):
             self.mkdir(mode)
-        except OSError:
-            _, e, _ = sys.exc_info()
-            if e.errno != errno.EEXIST:
-                raise
         return self
 
     def makedirs(self, mode=0o777):
@@ -1178,12 +1174,8 @@ class Path(str):
     def makedirs_p(self, mode=0o777):
         """ Like :meth:`makedirs`, but does not raise an exception if the
         directory already exists. """
-        try:
+        with contextlib.suppress(FileExistsError):
             self.makedirs(mode)
-        except OSError:
-            _, e, _ = sys.exc_info()
-            if e.errno != errno.EEXIST:
-                raise
         return self
 
     def rmdir(self):
@@ -1195,11 +1187,11 @@ class Path(str):
         """ Like :meth:`rmdir`, but does not raise an exception if the
         directory is not empty or does not exist. """
         try:
-            self.rmdir()
+            with contextlib.suppress(FileNotFoundError, FileExistsError):
+                self.rmdir()
         except OSError:
             _, e, _ = sys.exc_info()
-            bypass_codes = errno.ENOTEMPTY, errno.EEXIST, errno.ENOENT
-            if e.errno not in bypass_codes:
+            if e.errno != errno.ENOTEMPTY:
                 raise
         return self
 
@@ -1212,10 +1204,11 @@ class Path(str):
         """ Like :meth:`removedirs`, but does not raise an exception if the
         directory is not empty or does not exist. """
         try:
-            self.removedirs()
+            with contextlib.suppress(FileExistsError):
+                self.removedirs()
         except OSError:
             _, e, _ = sys.exc_info()
-            if e.errno != errno.ENOTEMPTY and e.errno != errno.EEXIST:
+            if e.errno != errno.ENOTEMPTY:
                 raise
         return self
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers
 	License :: OSI Approved :: MIT License
-	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules
@@ -23,10 +22,9 @@ classifiers =
 [options]
 py_modules =
 	path
-python_requires = >=2.7,!=3.1,!=3.2,!=3.3
+python_requires = >=3.5
 install_requires =
 	importlib_metadata>=0.5
-	backports.os; python_version=="2.7" and sys_platform=="linux2"
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]

--- a/test_path.py
+++ b/test_path.py
@@ -237,9 +237,6 @@ class TestBasics:
 
 
 class TestPerformance:
-    @pytest.mark.skipif(
-        path.PY2,
-        reason="Tests fail frequently on Python 2; see #153")
     def test_import_time(self, monkeypatch):
         """
         Import of path.py should take less than 100ms.
@@ -417,7 +414,7 @@ class TestScratchDir:
         reason="macOS disallows invalid encodings",
     )
     @pytest.mark.xfail(
-        platform.system() == 'Windows' and path.PY3,
+        platform.system() == 'Windows',
         reason="Can't write latin characters. See #133",
     )
     def test_listdir_other_encoding(self, tmpdir):
@@ -1236,7 +1233,6 @@ class TestMultiPath:
         assert path == input
 
 
-@pytest.mark.xfail('path.PY2', reason="Python 2 has no __future__")
 def test_no_dependencies():
     """
     Path.py guarantees that the path module can be


### PR DESCRIPTION
The future is here.

As outlined in #148, it's time to drop support for Python 2. This project will continue to support Python 2 on the 11.x series for bugfixes.